### PR TITLE
Unpack Android app from zip

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,0 +1,45 @@
+apply plugin: 'com.android.application'
+
+android {
+    compileSdkVersion 34
+
+    defaultConfig {
+        applicationId "com.example.glyphtoy"
+        minSdkVersion 33
+        targetSdkVersion 34
+        versionCode 1
+        versionName "1.0"
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+
+    // Enable Java 8 features
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    // Namespacing for Android resources
+    namespace "com.example.glyphtoy"
+}
+
+repositories {
+    flatDir {
+        dirs 'libs'
+    }
+}
+
+dependencies {
+    // Include the Nothing Glyph Matrix SDK from the libs folder
+    implementation(name: 'GlyphMatrixSDK', ext: 'aar')
+
+    // Basic AndroidX dependencies for a simple app with an Activity and view binding
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'androidx.core:core-ktx:1.12.0'
+    implementation 'com.google.android.material:material:1.11.0'
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.glyphtoy">
+
+    <!-- Required permission for Nothing glyph toys -->
+    <uses-permission android:name="com.nothing.ketchum.permission.ENABLE" />
+
+    <application
+        android:allowBackup="true"
+        android:label="@string/app_name"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.AppCompat.Light.NoActionBar">
+
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+
+        <!--
+         The following service definition registers a Glyph Toy with Nothing OS. It uses
+         metadata entries to provide the toy's name and a preview image so it can be
+         displayed in the system's Glyph Interface settings. Replace the class name
+         and resource identifiers with your own implementation when customizing.
+        -->
+        <service
+            android:name=".SampleToyService"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.nothing.glyph.TOY" />
+            </intent-filter>
+
+            <!-- Required: ensures your toy appears in the Glyph Toys list -->
+            <meta-data
+                android:name="com.nothing.glyph.toy.name"
+                android:resource="@string/toy_name" />
+
+
+            <!-- Optional: summary or description for your toy -->
+            <meta-data
+                android:name="com.nothing.glyph.toy.summary"
+                android:resource="@string/toy_summary" />
+
+            <!-- Optional: support long-press actions on the Glyph Button -->
+            <meta-data
+                android:name="com.nothing.glyph.toy.longpress"
+                android:value="1" />
+        
+            <!-- Optional: unterstützt die Anzeige im Always‑On‑Display (AOD) -->
+            <meta-data
+                android:name="com.nothing.glyph.toy.aod_support"
+                android:value="1" />
+        </service>
+
+    </application>
+
+</manifest>

--- a/app/src/main/java/com/example/glyphtoy/MainActivity.java
+++ b/app/src/main/java/com/example/glyphtoy/MainActivity.java
@@ -1,0 +1,103 @@
+package com.example.glyphtoy;
+
+import android.content.Intent;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.net.Uri;
+import android.os.Bundle;
+import android.provider.MediaStore;
+import android.view.View;
+import android.widget.Button;
+import android.widget.ImageView;
+
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Diese Aktivität ermöglicht es dem Benutzer, ein quadratisches Bild aus der Galerie
+ * auszuwählen und im internen Speicher abzulegen. Der ausgewählte Inhalt kann
+ * später vom {@link SampleToyService} gelesen werden, um ihn auf der Glyph Matrix
+ * darzustellen.
+ */
+public class MainActivity extends AppCompatActivity {
+    private static final int REQUEST_CODE_PICK_IMAGE = 1001;
+
+    private ImageView previewImageView;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_main);
+
+        previewImageView = findViewById(R.id.preview_image_view);
+        Button selectButton = findViewById(R.id.select_image_button);
+        selectButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                // Öffnet den Systemdialog zum Auswählen eines Bildes
+                Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
+                intent.setType("image/*");
+                startActivityForResult(Intent.createChooser(intent, "Bild auswählen"), REQUEST_CODE_PICK_IMAGE);
+            }
+        });
+
+        // Beim Start: Wenn ein Bild gespeichert wurde, lade die Vorschau
+        File imgFile = new File(getFilesDir(), "selected_glyph.png");
+        if (imgFile.exists()) {
+            Bitmap bitmap = BitmapFactory.decodeFile(imgFile.getAbsolutePath());
+            previewImageView.setImageBitmap(bitmap);
+        }
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        if (requestCode == REQUEST_CODE_PICK_IMAGE && resultCode == RESULT_OK && data != null) {
+            Uri uri = data.getData();
+            if (uri != null) {
+                try {
+                    Bitmap bitmap = getSquareBitmapFromUri(uri);
+                    saveBitmap(bitmap);
+                    previewImageView.setImageBitmap(bitmap);
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+    }
+
+    /**
+     * Lädt ein Bitmap aus der angegebenen Uri, skaliert und beschneidet es zu einem
+     * quadratischen Bild.
+     */
+    private Bitmap getSquareBitmapFromUri(Uri uri) throws IOException {
+        InputStream input = getContentResolver().openInputStream(uri);
+        Bitmap original = BitmapFactory.decodeStream(input);
+        if (original == null) {
+            throw new IOException("Konnte Bild nicht laden");
+        }
+        int size = Math.min(original.getWidth(), original.getHeight());
+        int x = (original.getWidth() - size) / 2;
+        int y = (original.getHeight() - size) / 2;
+        Bitmap squared = Bitmap.createBitmap(original, x, y, size, size);
+        return Bitmap.createScaledBitmap(squared, 25, 25, true);
+    }
+
+    /**
+     * Speichert das gegebene Bitmap im internen Speicher unter dem Namen
+     * {@code selected_glyph.png}. Wenn bereits eine Datei vorhanden ist, wird sie
+     * überschrieben.
+     */
+    private void saveBitmap(Bitmap bitmap) throws IOException {
+        File file = new File(getFilesDir(), "selected_glyph.png");
+        FileOutputStream out = new FileOutputStream(file);
+        bitmap.compress(Bitmap.CompressFormat.PNG, 100, out);
+        out.flush();
+        out.close();
+    }
+}

--- a/app/src/main/java/com/example/glyphtoy/SampleToyService.java
+++ b/app/src/main/java/com/example/glyphtoy/SampleToyService.java
@@ -1,0 +1,133 @@
+package com.example.glyphtoy;
+
+import android.app.Service;
+import android.content.Intent;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.IBinder;
+import android.os.Looper;
+import android.os.Message;
+import android.os.Messenger;
+
+import androidx.annotation.Nullable;
+
+import java.io.File;
+
+/**
+ * Ein Beispiel‑Dienst, der ein vom Benutzer ausgewähltes Bild als Glyph
+ * darstellt und optional den Always‑On‑Modus unterstützt. Das Bild wird aus
+ * dem internen Speicher geladen, in ein Integer‑Array konvertiert und dann über
+ * den {@code GlyphMatrixManager} an die Matrix gesendet. Wenn die AOD‑Funktion
+ * aktiviert ist, aktualisiert der Dienst bei jedem AOD‑Event das Bild auf der
+ * Matrix.
+ *
+ * Beachten Sie: Für die Verwendung der Klassen {@code GlyphMatrixManager},
+ * {@code Glyph} und {@code GlyphToy} müssen Sie die richtigen Pakete aus der
+ * GlyphMatrixSDK importieren. Diese Datei enthält keine Importanweisungen für
+ * diese Klassen, weil sie im AAR enthalten sind. Fügen Sie sie entsprechend
+ * Ihrer Projektkonfiguration hinzu.
+ */
+public class SampleToyService extends Service {
+
+    // Verwalter für die Verbindung zur Glyph Matrix
+    private Object mGM;
+
+    // Empfängt Nachrichten vom System (z. B. AOD‑Events)
+    private final Handler serviceHandler = new Handler(Looper.getMainLooper()) {
+        @Override
+        public void handleMessage(Message msg) {
+            // Die Konstanten MSG_GLYPH_TOY, MSG_GLYPH_TOY_DATA und EVENT_AOD
+            // stammen aus der Klasse GlyphToy des Nothing SDK. Stellen Sie
+            // sicher, dass Sie die Klasse importieren und verwenden.
+            switch (msg.what) {
+                // case GlyphToy.MSG_GLYPH_TOY:
+                //     Bundle bundle = msg.getData();
+                //     String event = bundle.getString(GlyphToy.MSG_GLYPH_TOY_DATA);
+                //     if (GlyphToy.EVENT_AOD.equals(event)) {
+                //         // Beim AOD‑Ereignis die Matrix erneut mit dem Bild füllen
+                //         int[] data = loadImageData();
+                //         if (mGM != null && data != null) {
+                //             // ((GlyphMatrixManager)mGM).setMatrixFrame(data);
+                //         }
+                //     }
+                //     break;
+                default:
+                    super.handleMessage(msg);
+            }
+        }
+    };
+
+    private final Messenger serviceMessenger = new Messenger(serviceHandler);
+
+    @Nullable
+    @Override
+    public IBinder onBind(Intent intent) {
+        // Initialisierung der Glyph‑Verbindung und Anzeige des Bildes
+        initGlyph();
+        return serviceMessenger.getBinder();
+    }
+
+    @Override
+    public boolean onUnbind(Intent intent) {
+        // Bei Beendigung die Verbindung trennen
+        if (mGM != null) {
+            try {
+                // ((GlyphMatrixManager)mGM).unInit();
+            } catch (Exception e) {
+                // ignorieren
+            }
+            mGM = null;
+        }
+        return super.onUnbind(intent);
+    }
+
+    /**
+     * Initialisiert den GlyphMatrixManager, registriert das Gerät und sendet das
+     * aktuell gespeicherte Bild an die Matrix. Diese Methode enthält bewusst
+     * keine konkrete Implementierung der SDK‑Aufrufe; die entsprechenden
+     * Methoden sind in den Kommentaren erwähnt und müssen mit den richtigen
+     * Klassen des AAR ersetzt werden.
+     */
+    private void initGlyph() {
+        try {
+            // mGM = new GlyphMatrixManager();
+            // ((GlyphMatrixManager)mGM).init(null); // Callback implementieren falls benötigt
+            // ((GlyphMatrixManager)mGM).register(Glyph.DEVICE_23112);
+
+            int[] data = loadImageData();
+            if (data != null) {
+                // ((GlyphMatrixManager)mGM).setMatrixFrame(data);
+            }
+        } catch (Exception e) {
+            // Fehlerbehandlung (optional)
+        }
+    }
+
+    /**
+     * Lädt das gespeicherte Glyph‑Bild und konvertiert es in ein Integer‑Array
+     * mit ARGB‑Werten. Dieses Array entspricht einem 25×25‑Raster und kann
+     * direkt an {@code setMatrixFrame(int[])} übergeben werden【751807440283616†L495-L506】.
+     */
+    private int[] loadImageData() {
+        File file = new File(getFilesDir(), "selected_glyph.png");
+        if (!file.exists()) {
+            return null;
+        }
+        Bitmap bitmap = BitmapFactory.decodeFile(file.getAbsolutePath());
+        if (bitmap == null) {
+            return null;
+        }
+        int width = bitmap.getWidth();
+        int height = bitmap.getHeight();
+        int[] data = new int[width * height];
+        int index = 0;
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                data[index++] = bitmap.getPixel(x, y);
+            }
+        }
+        return data;
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="24dp"
+    android:gravity="center_horizontal">
+
+    <!-- Begrüßungstext -->
+    <TextView
+        android:id="@+id/hello_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
+        android:text="Willkommen bei GlyphToy"
+        android:textAppearance="?attr/textAppearanceHeadline5" />
+
+    <!-- Schaltfläche zum Auswählen eines Bildes -->
+    <Button
+        android:id="@+id/select_image_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Bild auswählen" />
+
+    <!-- Vorschaubild für das ausgewählte Glyph -->
+    <ImageView
+        android:id="@+id/preview_image_view"
+        android:layout_width="200dp"
+        android:layout_height="200dp"
+        android:layout_marginTop="16dp"
+        android:contentDescription="Vorschaubild"
+        android:scaleType="centerCrop" />
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">GlyphToy</string>
+    <string name="toy_name">Sample Glyph Toy</string>
+    <string name="toy_summary">Eine einfache Glyph Toy-Demonstration.</string>
+</resources>


### PR DESCRIPTION
## Summary
- extract GlyphToy Android app module from provided archive
- include MainActivity for choosing and saving a square image
- add SampleToyService and manifest configuration for Glyph matrix
- remove unused preview image drawable and related references

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689311593a288327a7b37bffdfb5d172