### PR TITLE
feat: update gradle to version 9

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 34
+    compileSdk 34
 
     defaultConfig {
         applicationId "com.example.glyphtoy"
-        minSdkVersion 33
-        targetSdkVersion 34
+        minSdk 33
+        targetSdk 34
         versionCode 1
         versionName "1.0"
     }

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         // You might need to update the version of the Android Gradle plugin based on your Android Studio
-        classpath 'com.android.tools.build:gradle:8.1.0'
+        classpath 'com.android.tools.build:gradle:8.12.0'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
- Update gradle wrapper to use Gradle 9.0 distribution
- Bump Android Gradle plugin to 8.12.0
- Switch module SDK declarations to new DSL keys for Gradle 9 compatibility

## Testing
- `./gradlew --version` *(fails: java.io.FileNotFoundException: https://github.com/gradle/gradle-distributions/releases/download/v9.0.0/gradle-9.0-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_6893461d339c8327943094df99c27685