### PR TITLE
Integrate Firebase Crashlytics

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.application'
+apply plugin: 'com.google.firebase.crashlytics'
 
 android {
     compileSdk 34
@@ -36,4 +37,8 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'androidx.core:core-ktx:1.12.0'
     implementation 'com.google.android.material:material:1.11.0'
+
+    // Firebase Crashlytics
+    implementation platform('com.google.firebase:firebase-bom:34.1.0')
+    implementation 'com.google.firebase:firebase-crashlytics'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="com.nothing.ketchum.permission.ENABLE" />
 
     <application
+        android:name=".GlyphApplication"
         android:allowBackup="true"
         android:label="Static Glyph"
         android:supportsRtl="true"

--- a/app/src/main/java/com/grsr/staticGlyph/CrashlyticsUtil.java
+++ b/app/src/main/java/com/grsr/staticGlyph/CrashlyticsUtil.java
@@ -1,0 +1,29 @@
+package com.grsr.staticGlyph;
+
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
+
+/**
+ * Utility wrapper around {@link FirebaseCrashlytics} to simplify logging of
+ * breadcrumbs and exceptions throughout the app.
+ */
+public final class CrashlyticsUtil {
+
+    private CrashlyticsUtil() {
+        // Utility class
+    }
+
+    /**
+     * Adds a breadcrumb entry to Crashlytics.
+     */
+    public static void log(String message) {
+        FirebaseCrashlytics.getInstance().log(message);
+    }
+
+    /**
+     * Records a non-fatal exception in Crashlytics.
+     */
+    public static void recordException(Throwable throwable) {
+        FirebaseCrashlytics.getInstance().recordException(throwable);
+    }
+}
+

--- a/app/src/main/java/com/grsr/staticGlyph/GlyphApplication.java
+++ b/app/src/main/java/com/grsr/staticGlyph/GlyphApplication.java
@@ -1,0 +1,21 @@
+package com.grsr.staticGlyph;
+
+import android.app.Application;
+
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
+
+/**
+ * Application class that initialises Firebase and enables Crashlytics
+ * collection at startup.
+ */
+public class GlyphApplication extends Application {
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        FirebaseApp.initializeApp(this);
+        FirebaseCrashlytics.getInstance().setCrashlyticsCollectionEnabled(true);
+    }
+}
+

--- a/app/src/main/java/com/grsr/staticGlyph/MainActivity.java
+++ b/app/src/main/java/com/grsr/staticGlyph/MainActivity.java
@@ -39,6 +39,8 @@ public class MainActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
+        CrashlyticsUtil.log("MainActivity#onCreate");
+
         previewImageView = findViewById(R.id.preview_image_view);
         previewBitpmapView = findViewById(R.id.preview_bitmap_view);
         Button selectButton = findViewById(R.id.select_image_button);
@@ -74,6 +76,7 @@ public class MainActivity extends AppCompatActivity {
     @Override
     protected void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
+        CrashlyticsUtil.log("MainActivity#onActivityResult");
         if (requestCode == REQUEST_CODE_PICK_IMAGE && resultCode == RESULT_OK && data != null) {
             Uri uri = data.getData();
             if (uri != null) {
@@ -97,6 +100,7 @@ public class MainActivity extends AppCompatActivity {
 
                 } catch (IOException e) {
                     e.printStackTrace();
+                    CrashlyticsUtil.recordException(e);
                 }
             }
         }
@@ -104,6 +108,7 @@ public class MainActivity extends AppCompatActivity {
 
 
     private Bitmap toGlyph25(Bitmap src) {
+        CrashlyticsUtil.log("MainActivity#toGlyph25");
         final int TARGET = 25;
         Bitmap scaled = Bitmap.createBitmap(TARGET, TARGET, Bitmap.Config.ARGB_8888);
         Canvas canvas = new Canvas(scaled);
@@ -159,6 +164,7 @@ public class MainActivity extends AppCompatActivity {
      * überschrieben.
      */
     private void saveBitmap(Bitmap bitmap) throws IOException {
+        CrashlyticsUtil.log("MainActivity#saveBitmap");
         File file = new File(getFilesDir(), "selected_glyph.png");
         FileOutputStream out = new FileOutputStream(file);
         bitmap.compress(Bitmap.CompressFormat.PNG, 100, out);
@@ -170,6 +176,7 @@ public class MainActivity extends AppCompatActivity {
      * Speichert das Vorschaubild unter dem Namen {@code selected_glyph_preview.png}.
      */
     private void savePreviewBitmap(Bitmap bitmap) throws IOException {
+        CrashlyticsUtil.log("MainActivity#savePreviewBitmap");
         File file = new File(getFilesDir(), "selected_glyph_preview.png");
         FileOutputStream out = new FileOutputStream(file);
         bitmap.compress(Bitmap.CompressFormat.PNG, 100, out);

--- a/app/src/main/java/com/grsr/staticGlyph/staticToyService.java
+++ b/app/src/main/java/com/grsr/staticGlyph/staticToyService.java
@@ -44,6 +44,7 @@ public class staticToyService extends Service {
     private final Handler serviceHandler = new Handler(Looper.getMainLooper()) {
         @Override
         public void handleMessage(Message msg) {
+            CrashlyticsUtil.log("staticToyService#handleMessage");
             switch (msg.what) {
                 case GlyphToy.MSG_GLYPH_TOY: {
                     Bundle bundle = msg.getData();
@@ -55,6 +56,7 @@ public class staticToyService extends Service {
 
                                 mGM.setMatrixFrame(data);
                             } catch (GlyphException e) {
+                                CrashlyticsUtil.recordException(e);
                                 throw new RuntimeException(e);
                             }
                         }
@@ -72,6 +74,7 @@ public class staticToyService extends Service {
     @Nullable
     @Override
     public IBinder onBind(Intent intent) {
+        CrashlyticsUtil.log("staticToyService#onBind");
         // Initialisierung der Glyph‑Verbindung und Anzeige des Bildes
         initGlyph();
         return serviceMessenger.getBinder();
@@ -79,6 +82,7 @@ public class staticToyService extends Service {
 
     @Override
     public boolean onUnbind(Intent intent) {
+        CrashlyticsUtil.log("staticToyService#onUnbind");
         mGM.unInit();
         mGM.turnOff();
         mGM = null;
@@ -95,6 +99,7 @@ public class staticToyService extends Service {
      * Klassen des AAR ersetzt werden.
      */
     private void initGlyph() {
+        CrashlyticsUtil.log("staticToyService#initGlyph");
         try {
              mGM = GlyphMatrixManager.getInstance(getApplicationContext());
              mGM.init(null);
@@ -105,7 +110,7 @@ public class staticToyService extends Service {
                 mGM.setMatrixFrame(data);
             }
         } catch (Exception e) {
-            // Fehlerbehandlung (optional)
+            CrashlyticsUtil.recordException(e);
         }
     }
 
@@ -115,6 +120,7 @@ public class staticToyService extends Service {
      * direkt an {@code setMatrixFrame(int[])} übergeben werden【751807440283616†L495-L506】.
      */
     private int[] loadImageData() {
+        CrashlyticsUtil.log("staticToyService#loadImageData");
         File file = new File(getFilesDir(), "selected_glyph.png");
         if (!file.exists()) {
             return null;

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ buildscript {
     dependencies {
         // You might need to update the version of the Android Gradle plugin based on your Android Studio
         classpath 'com.android.tools.build:gradle:8.12.0'
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.9'
     }
 }
 


### PR DESCRIPTION
## Summary
- add Crashlytics Gradle plugin and dependencies
- create application and helper to initialize and log to Firebase Crashlytics
- record exceptions and breadcrumbs in activities and service

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e0b3707588327a89e33202f7eb633